### PR TITLE
Improve icon logic

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -4,7 +4,9 @@ Purse unlocks APIs for the CoreGui backpack which were previously locked to othe
 
 ## Methods
 
-``` lua title="LocalScript - Inventory Toggle Button" linenums="1"
+The following code sample, placed within a child `LocalScript` of a `GuiButton`, uses [`OpenClose()`](#openclose) to toggle the inventory on the button's `Activated` event.
+
+``` lua title="Inventory Toggle Button" linenums="1"
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local Purse = require(ReplicatedStorage.Purse)
@@ -85,6 +87,22 @@ VRClosesNonExclusive: boolean
 Returns true.
 
 ## Events
+
+The following code sample, placed within a child `LocalScript` of `StarterPlayerScripts`, uses [`StateChanged`](#statechanged) detect when the inventory is toggled and prints it's state to output.
+
+``` lua title="Detect Inventory State" linenums="1"
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local Purse = require(ReplicatedStorage.Purse)
+
+Purse.StateChanged.Event:Connect(function(isNowOpen)
+	if isNowOpen then
+		print("Inventory opened")
+	else
+		print("Inventory closed")
+	end
+end)
+```
 
 ### StateChanged
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -88,7 +88,7 @@ Returns true.
 
 ## Events
 
-The following code sample, placed within a child `LocalScript` of `StarterPlayerScripts`, uses [`StateChanged`](#statechanged) detect when the inventory is toggled and prints it's state to output.
+The following code sample, placed within a child `LocalScript` of `StarterPlayerScripts`, uses [`StateChanged`](#statechanged) to detect when the inventory is toggled and prints its state to output.
 
 ``` lua title="Detect Inventory State" linenums="1"
 local ReplicatedStorage = game:GetService("ReplicatedStorage")

--- a/src/TopbarIcon.client.luau
+++ b/src/TopbarIcon.client.luau
@@ -3,8 +3,8 @@
 local BackpackScript = require(script.Parent)
 local Icon = require(script.Parent.Parent.topbarplus)
 
-local iconSelectedImage = "rbxasset://textures/ui/TopBar/inventoryOn.png"
-local iconDeselectedImage = "rbxasset://textures/ui/TopBar/inventoryOff.png"
+local ICON_SELECTED_IMAGE = "rbxasset://textures/ui/TopBar/inventoryOn.png"
+local ICON_DESELECTED_IMAGE = "rbxasset://textures/ui/TopBar/inventoryOff.png"
 
 local icon = Icon.new()
 icon:setCaption("Inventory")

--- a/src/TopbarIcon.client.luau
+++ b/src/TopbarIcon.client.luau
@@ -17,15 +17,16 @@ icon:autoDeselect(false)
 icon:setOrder(-1)
 icon:bindToggleKey(Enum.KeyCode.Backquote)
 
-UserInputService.InputBegan:Connect(function(input: InputObject, gameProcessedEvent: boolean): ()
-	local inputType = input.UserInputType
-	if not gameProcessedEvent then
-		if inputType == Enum.UserInputType.MouseButton1 or inputType == Enum.UserInputType.Touch then
-			icon:deselect()
-		end
+BackpackScript.StateChanged.Event:Connect(function(isNowOpen)
+	if isNowOpen then
+		icon:select()
+	else
+		icon:deselect()
 	end
 end)
 
-icon.toggled:Connect(function(): ()
-	BackpackScript.OpenClose()
+icon.toggled:Connect(function(_isSelected, fromSource)
+	if fromSource == "User" then
+		BackpackScript.OpenClose()
+	end
 end)

--- a/src/TopbarIcon.client.luau
+++ b/src/TopbarIcon.client.luau
@@ -8,8 +8,8 @@ local ICON_DESELECTED_IMAGE = "rbxasset://textures/ui/TopBar/inventoryOff.png"
 
 local icon = Icon.new()
 icon:setCaption("Inventory")
-icon:setImage(iconSelectedImage, "Selected")
-icon:setImage(iconDeselectedImage, "Deselected")
+icon:setImage(ICON_SELECTED_IMAGE, "Selected")
+icon:setImage(ICON_DESELECTED_IMAGE, "Deselected")
 icon:setImageScale(1)
 icon:autoDeselect(false)
 icon:setOrder(-1)

--- a/src/TopbarIcon.client.luau
+++ b/src/TopbarIcon.client.luau
@@ -1,7 +1,5 @@
 --!strict
 
-local UserInputService = game:GetService("UserInputService")
-
 local BackpackScript = require(script.Parent)
 local Icon = require(script.Parent.Parent.topbarplus)
 


### PR DESCRIPTION
This pull request updates the documentation and refactors the `TopbarIcon.client.luau` script to improve clarity and functionality for the CoreGui backpack inventory toggle and state handling. The main changes include clearer sample code in the API docs and a more robust event-driven approach in the icon script.

**Documentation improvements:**

* Added a descriptive code sample showing how to toggle the inventory using `OpenClose()` from a button's `Activated` event.
* Added a sample demonstrating how to listen for the `StateChanged` event to detect when the inventory is opened or closed.

**Code refactoring and event handling:**

* Renamed image asset variables in `TopbarIcon.client.luau` to uppercase for clarity and consistency.
* Replaced manual input handling with a connection to `BackpackScript.StateChanged.Event` to update the icon's selected state based on inventory open/close events.
* Updated the icon toggle logic to only call `BackpackScript.OpenClose()` when the toggle is initiated by the user, improving separation of concerns and preventing redundant toggles.