### PR TITLE
Add attribution script

### DIFF
--- a/src/Attribution.client.luau
+++ b/src/Attribution.client.luau
@@ -1,0 +1,18 @@
+--[[
+	Purse is licensed under the Apache License, Version 2.0.
+
+	This script serves as the license notice for Purse.
+
+	By using Purse, you are required to do one of the following:
+		1. Keep the Attribution script unmodified and enabled
+		2. Credit Purse in your experience description by name and creator (@WinnersTakesAll)
+		3. Have a DevForum topic linked in your experience description, crediting Purse with the above
+
+	Thank you for supporting Purse. For more, consider sponsoring Purse to support its development.
+]]
+
+local RunService = game:GetService("RunService")
+
+if not RunService:IsStudio() then
+	print("👛 Running Purse v1.1.0 by @WinnersTakesAll")
+end


### PR DESCRIPTION
This pull request adds an attribution and license notice script for the Purse project. The script ensures that users are informed about the licensing requirements and proper crediting for using Purse.

License and attribution enforcement:

* Added a new script, `Attribution.client.luau`, which displays a license notice for Purse and outlines the requirements for attribution or credit when using the project. The script prints a version and author message when not running in Studio mode.