### PR TITLE
Add warning for having both Purse and the CoreGui backpack enabled

### DIFF
--- a/src/CoreGuiWarn.client.luau
+++ b/src/CoreGuiWarn.client.luau
@@ -1,0 +1,10 @@
+local RunService = game:GetService("RunService")
+local StarterGui = game:GetService("StarterGui")
+
+local connection
+connection = RunService.Heartbeat:Connect(function()
+	if StarterGui:GetCoreGuiEnabled(Enum.CoreGuiType.Backpack) then
+		warn("Purse and CoreGui backpack enabled at the same time")
+		connection:Disconnect()
+	end
+end)

--- a/src/CoreGuiWarn.client.luau
+++ b/src/CoreGuiWarn.client.luau
@@ -1,10 +1,10 @@
-local RunService = game:GetService("RunService")
 local StarterGui = game:GetService("StarterGui")
 
-local connection
-connection = RunService.Heartbeat:Connect(function()
-	if StarterGui:GetCoreGuiEnabled(Enum.CoreGuiType.Backpack) then
-		warn("Purse and CoreGui backpack enabled at the same time")
-		connection:Disconnect()
+task.spawn(function()
+	while task.wait(3) do
+		if StarterGui:GetCoreGuiEnabled(Enum.CoreGuiType.Backpack) then
+			warn("Purse and CoreGui backpack enabled at the same time")
+			break
+		end
 	end
 end)


### PR DESCRIPTION
This pull request introduces a background warning mechanism to detect when both the custom "Purse" UI and the CoreGui backpack are enabled simultaneously. This helps catch potential UI conflicts during development or testing.

CoreGui conflict detection:

* Added a background task in `src/CoreGuiWarn.client.luau` that periodically checks if the CoreGui backpack is enabled and issues a warning if it is active alongside the "Purse" UI.