### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: CI
 
-permissions:
-  contents: read
-
 on:
   pull_request:
     paths:
@@ -16,6 +13,9 @@ on:
 env:
   OUTPUT_NAME: Purse
   BUILD_PROJECT: package.project.json
+
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/ryanlua/purse/security/code-scanning/1](https://github.com/ryanlua/purse/security/code-scanning/1)

In general, to fix this issue you explicitly declare a `permissions:` block either at the root of the workflow (so it applies to all jobs by default) or under each job, restricting `GITHUB_TOKEN` to the minimal scopes required. Here, the CI job only needs to read repository contents (for checkout) and upload artifacts (which does not require broader repo permissions), so `contents: read` is sufficient.

The best minimal fix without changing functionality is to add a workflow‑level `permissions:` block directly under the `name: CI` line in `.github/workflows/ci.yml`. This will apply to the `build` job (and any future jobs that don’t override `permissions`) and ensure `GITHUB_TOKEN` is scoped to read‑only contents. No additional imports or methods are needed; it’s a pure YAML configuration change.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between line 2 (the blank line after `name: CI`) and line 3 (`on:`).  
- All existing steps remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
