### PR TITLE
Update topbar icon to use fonts

### DIFF
--- a/src/TopbarIcon.client.luau
+++ b/src/TopbarIcon.client.luau
@@ -4,6 +4,7 @@ local BackpackScript = require(script.Parent)
 local Icon = require(script.Parent.Parent.topbarplus)
 
 local icon = Icon.new()
+icon:modifyTheme({ "IconLabelContainer", "TargetWidth", 0 }) -- Force minimum width
 icon:setLabel("backpack")
 icon:setOrder(-1)
 icon:setTextSize(24)

--- a/src/TopbarIcon.client.luau
+++ b/src/TopbarIcon.client.luau
@@ -7,13 +7,14 @@ local ICON_SELECTED_IMAGE = "rbxasset://textures/ui/TopBar/inventoryOn.png"
 local ICON_DESELECTED_IMAGE = "rbxasset://textures/ui/TopBar/inventoryOff.png"
 
 local icon = Icon.new()
-icon:setCaption("Inventory")
-icon:setImage(ICON_SELECTED_IMAGE, "Selected")
-icon:setImage(ICON_DESELECTED_IMAGE, "Deselected")
-icon:setImageScale(1)
-icon:autoDeselect(false)
+icon:setLabel("backpack")
 icon:setOrder(-1)
+icon:setTextSize(24)
+icon:setTextFont("rbxasset://LuaPackages/Packages/_Index/BuilderIcons/BuilderIcons/BuilderIcons.json", Enum.FontWeight.Bold, Enum.FontStyle.Normal, "Selected")
+icon:setTextFont("rbxasset://LuaPackages/Packages/_Index/BuilderIcons/BuilderIcons/BuilderIcons.json", Enum.FontWeight.Regular, Enum.FontStyle.Normal, "Deselected")
 icon:bindToggleKey(Enum.KeyCode.Backquote)
+icon:autoDeselect(false)
+icon:setCaption("Inventory")
 
 BackpackScript.StateChanged.Event:Connect(function(isNowOpen)
 	if isNowOpen then

--- a/src/TopbarIcon.client.luau
+++ b/src/TopbarIcon.client.luau
@@ -10,8 +10,18 @@ local icon = Icon.new()
 icon:setLabel("backpack")
 icon:setOrder(-1)
 icon:setTextSize(24)
-icon:setTextFont("rbxasset://LuaPackages/Packages/_Index/BuilderIcons/BuilderIcons/BuilderIcons.json", Enum.FontWeight.Bold, Enum.FontStyle.Normal, "Selected")
-icon:setTextFont("rbxasset://LuaPackages/Packages/_Index/BuilderIcons/BuilderIcons/BuilderIcons.json", Enum.FontWeight.Regular, Enum.FontStyle.Normal, "Deselected")
+icon:setTextFont(
+	"rbxasset://LuaPackages/Packages/_Index/BuilderIcons/BuilderIcons/BuilderIcons.json",
+	Enum.FontWeight.Bold,
+	Enum.FontStyle.Normal,
+	"Selected"
+)
+icon:setTextFont(
+	"rbxasset://LuaPackages/Packages/_Index/BuilderIcons/BuilderIcons/BuilderIcons.json",
+	Enum.FontWeight.Regular,
+	Enum.FontStyle.Normal,
+	"Deselected"
+)
 icon:bindToggleKey(Enum.KeyCode.Backquote)
 icon:autoDeselect(false)
 icon:setCaption("Inventory")

--- a/src/TopbarIcon.client.luau
+++ b/src/TopbarIcon.client.luau
@@ -3,9 +3,6 @@
 local BackpackScript = require(script.Parent)
 local Icon = require(script.Parent.Parent.topbarplus)
 
-local ICON_SELECTED_IMAGE = "rbxasset://textures/ui/TopBar/inventoryOn.png"
-local ICON_DESELECTED_IMAGE = "rbxasset://textures/ui/TopBar/inventoryOff.png"
-
 local icon = Icon.new()
 icon:setLabel("backpack")
 icon:setOrder(-1)


### PR DESCRIPTION
Use the backpack vector icon from the builder icons font for the icon.

<img width="852" height="354" alt="image" src="https://github.com/user-attachments/assets/b60cddb4-c3d3-4656-8a1e-a98d56a0dcab" />

This pull request updates the appearance and configuration of the topbar inventory icon in `src/TopbarIcon.client.luau`. The main focus is on improving the icon's label, font, and layout for better clarity and consistency.

**UI and Label Improvements:**

* Replaced the previous image-based icon with a text label ("backpack") and updated the label styling, including font, size, and weight for both selected and deselected states.
* Forced a minimum width for the icon label container to ensure consistent layout.

**Configuration Adjustments:**

* Set the icon's order, toggle key, and auto-deselect behavior, and restored the "Inventory" caption.