### PR TITLE
Add warning for outdated versions

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -12,7 +12,8 @@ Purse uses the following capabilities:
 
 * **RunClientScript** - Run Purse on the client
 * **AccessOutsideWrite** - Access instances outside the container
-* **AssetManagement** - Check for latest version
+* **AssetRead** - Check for latest version
+* **AssetManagement** - Preload icon images
     * This capability does not allow read, create, or update operations on assets
 * **Basic** - Run Purse
 * **CreateInstances** - Create GUI instances

--- a/models/Purse/init.meta.json
+++ b/models/Purse/init.meta.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "Capabilities": {
-      "SecurityCapabilities": 155727694080
+      "SecurityCapabilities": 224447170816
     },
     "Sandboxed": true
   }

--- a/src/Attribution.client.luau
+++ b/src/Attribution.client.luau
@@ -43,5 +43,7 @@ end
 
 -- Check for updates. You may modify the below
 if latestVersion and latestVersion ~= VERSION then
-	warn(`A new version of Purse (v{VERSION} -> v{latestVersion}) is available: https://create.roblox.com/store/asset/112061170330936`)
+	warn(
+		`A new version of Purse (v{VERSION} -> v{latestVersion}) is available: https://create.roblox.com/store/asset/112061170330936`
+	)
 end

--- a/src/Attribution.client.luau
+++ b/src/Attribution.client.luau
@@ -18,7 +18,7 @@
 
 --[[
 	By using Purse, you agree to provide attribution in one of the following ways:
-		1. Keep the Attribution script unmodified and enabled
+		1. Keep the attribution unmodified and enabled
 		2. Provide credit in your experience description by name (Purse) and creator (@WinnersTakesAll)
 		3. Have a DevForum topic linked in your experience description, crediting with the above
 
@@ -28,8 +28,20 @@
 	Thank you for supporting Purse.
 ]]
 
+local MarketplaceService = game:GetService("MarketplaceService")
 local RunService = game:GetService("RunService")
 
+local asset = MarketplaceService:GetProductInfoAsync(112061170330936)
+local latestVersion = string.match(asset.Name, "v(%d+%.%d+%.%d+)")
+
+local VERSION = "1.1.4"
+
+-- Print attribution. Do not modify without reading above
 if not RunService:IsStudio() then
-	print("👛 Running Purse v1.1.4 by @WinnersTakesAll")
+	print(`👛 Running Purse v{VERSION} by @WinnersTakesAll`)
+end
+
+-- Check for updates. You may modify the below
+if latestVersion and latestVersion ~= VERSION then
+	warn(`A new version of Purse (v{VERSION} -> v{latestVersion}) is available: https://create.roblox.com/store/asset/112061170330936`)
 end

--- a/src/Attribution.client.luau
+++ b/src/Attribution.client.luau
@@ -31,9 +31,6 @@
 local MarketplaceService = game:GetService("MarketplaceService")
 local RunService = game:GetService("RunService")
 
-local asset = MarketplaceService:GetProductInfoAsync(112061170330936)
-local latestVersion = string.match(asset.Name, "v(%d+%.%d+%.%d+)")
-
 local VERSION = "1.1.4"
 
 -- Print attribution. Do not modify without reading above
@@ -42,6 +39,16 @@ if not RunService:IsStudio() then
 end
 
 -- Check for updates. You may modify the below
+local latestVersion: string?
+
+local success, result = pcall(function()
+	return MarketplaceService:GetProductInfoAsync(112061170330936)
+end)
+
+if success then
+	latestVersion = string.match(result.Name, "v(%d+%.%d+%.%d+)")
+end
+
 if latestVersion and latestVersion ~= VERSION then
 	warn(
 		`A new version of Purse (v{VERSION} -> v{latestVersion}) is available: https://create.roblox.com/store/asset/112061170330936`


### PR DESCRIPTION
Makes it so that if the version is outdated, it warns about it in the output.

Checks the below asset's name to match `v*.*.*`, which determines the latest version and compares it to the internal version.

https://create.roblox.com/store/asset/112061170330936