### PR TITLE
Fix capabilities for equipping and unequipping tools

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,8 +1,10 @@
-[Script capabilities] is used to sandbox Purse to ensure safety and prevent malicious code.
+[Script capabilities] is used to sandbox Purse and tools to ensure safety and prevent malicious code.
 
-!!! danger
+This is optional and disabled by default by can be enabled using the [`Sandboxed`][Sandboxed] property.
 
-    Malicious clones may remove script capabilities sandboxing. Double check the [`Capabilities`][Capabilities] property and that [`Sandboxed`][Sandboxed] is enabled.
+!!! warning
+
+    By enabling script capabilities, any tools will be sandboxed. Make sure you have [`Capabilities`][Capabilities] for your tools set on top of Purse or your tools will error.
 
   [Script capabilities]: https://create.roblox.com/docs/scripting/capabilities
   [Capabilities]: https://create.roblox.com/docs/scripting/capabilities#capabilities

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -15,6 +15,8 @@ Purse uses the following capabilities:
 * **AssetRead** - Check for latest version
 * **AssetManagement** - Preload icon images
     * This capability does not allow read, create, or update operations on assets
+* **AvatarAppearance** - Equip and unequip tools
+* **AvatarBehavior** - Equip and unequip tools
 * **Basic** - Run Purse
 * **CreateInstances** - Create GUI instances
 * **Input** - Binding for equipping slots and toggling inventory

--- a/docs/sandboxing.md
+++ b/docs/sandboxing.md
@@ -1,10 +1,10 @@
 [Script capabilities] is used to sandbox Purse and tools to ensure safety and prevent malicious code.
 
-This is optional and disabled by default by can be enabled using the [`Sandboxed`][Sandboxed] property.
+This is optional and disabled by default but can be enabled using the [`Sandboxed`][Sandboxed] property.
 
 !!! warning
 
-    By enabling script capabilities, any tools will be sandboxed. Make sure you have [`Capabilities`][Capabilities] for your tools set on top of Purse or your tools will error.
+    By enabling script capabilities, all tools will be sandboxed. Make sure you have [`Capabilities`][Capabilities] for your tools set on top of Purse or they will error.
 
   [Script capabilities]: https://create.roblox.com/docs/scripting/capabilities
   [Capabilities]: https://create.roblox.com/docs/scripting/capabilities#capabilities

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,6 @@ nav:
   - Installation: installation.md
   - Guide: guide.md
   - Performance: performance.md
-  - Capabilities: capabilities.md
+  - Sandboxing: sandboxing.md
   - Philosophy: philosophy.md
   - API Reference: api-reference.md

--- a/models/Purse/init.meta.json
+++ b/models/Purse/init.meta.json
@@ -1,8 +1,8 @@
 {
   "properties": {
     "Capabilities": {
-      "SecurityCapabilities": 224447170816
+      "SecurityCapabilities": 9007424238782720
     },
-    "Sandboxed": true
+    "Sandboxed": false
   }
 }


### PR DESCRIPTION
Disables sandboxing by default and adds missing capabilities.

Instead of using sandboxing always to sandbox everything, including tools, it should be disabled for backwards compatibility.