### PR TITLE
Drop HopperBin support

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -331,7 +331,10 @@ local function GetOffset(guiObject, point)
 end
 
 local function DisableActiveHopper() --NOTE: HopperBin
-	ActiveHopper:ToggleSelect()
+	-- ROBLOX deviation START: remove HopperBin support (RobloxScriptSecurity)
+	-- ActiveHopper:ToggleSelect()
+	warn(`[Purse] Cannot deselect active hopper. HopperBin is deprecated and not supported.`)
+	-- ROBLOX deviation END
 	SlotsByTool[ActiveHopper]:UpdateEquipView()
 	ActiveHopper = nil
 end
@@ -348,7 +351,10 @@ end
 local function EquipNewTool(tool) --NOTE: HopperBin
 	UnequipAllTools()
 	if tool:IsA("HopperBin") then
-		tool:ToggleSelect()
+		-- ROBLOX deviation START: remove HopperBin support (RobloxScriptSecurity)
+		-- tool:ToggleSelect()
+		warn(`[Purse] Cannot select '{tool}' hopper. HopperBin is deprecated and not supported.`)
+		-- ROBLOX deviation END
 		SlotsByTool[tool]:UpdateEquipView()
 		ActiveHopper = tool
 	else

--- a/src/init.luau
+++ b/src/init.luau
@@ -332,11 +332,11 @@ end
 
 local function DisableActiveHopper() --NOTE: HopperBin
 	-- ROBLOX deviation START: remove HopperBin support (RobloxScriptSecurity)
-	-- ActiveHopper:ToggleSelect()
 	warn(`[Purse] Cannot deselect active hopper. HopperBin is deprecated and not supported.`)
+	-- ActiveHopper:ToggleSelect()
+	-- SlotsByTool[ActiveHopper]:UpdateEquipView()
+	-- ActiveHopper = nil
 	-- ROBLOX deviation END
-	SlotsByTool[ActiveHopper]:UpdateEquipView()
-	ActiveHopper = nil
 end
 
 local function UnequipAllTools() --NOTE: HopperBin
@@ -352,11 +352,11 @@ local function EquipNewTool(tool) --NOTE: HopperBin
 	UnequipAllTools()
 	if tool:IsA("HopperBin") then
 		-- ROBLOX deviation START: remove HopperBin support (RobloxScriptSecurity)
-		-- tool:ToggleSelect()
 		warn(`[Purse] Cannot select '{tool}' hopper. HopperBin is deprecated and not supported.`)
+		-- tool:ToggleSelect()
+		-- SlotsByTool[tool]:UpdateEquipView()
+		-- ActiveHopper = tool
 		-- ROBLOX deviation END
-		SlotsByTool[tool]:UpdateEquipView()
-		ActiveHopper = tool
 	else
 		--Humanoid:EquipTool(tool) --NOTE: This would also unequip current Tool
 		tool.Parent = Character --TODO: Switch back to above line after EquipTool is fixed!


### PR DESCRIPTION
Drops support for [HopperBin](https://create.roblox.com/docs/reference/engine/classes/HopperBin) and related errors